### PR TITLE
Fix skip links script code standards

### DIFF
--- a/js/genwpacc-skiplinks.js
+++ b/js/genwpacc-skiplinks.js
@@ -1,23 +1,18 @@
-/*  genesis-accessible skiplinks
-
-	Version: 1.0
-
-	License: GPL-2.0+
-	License URI: http://www.opensource.org/licenses/gpl-license.php
-
+/**
+ * genesis-accessible skiplinks
+ * Version: 1.0
+ * License: GPL-2.0+
+ * License URI: http://www.opensource.org/licenses/gpl-license.php
  */
 
-window.addEventListener("hashchange", function(event) {
+window.addEventListener( 'hashchange', function() {
+	'use strict';
+	var element = document.getElementById( location.hash.substring( 1 ) );
 
-    var element = document.getElementById(location.hash.substring(1));
-
-    if (element) {
-
-        if (!/^(?:a|select|input|button|textarea)$/i.test(element.tagName)) {
-            element.tabIndex = -1;
-        }
-
-        element.focus();
-    }
-
+	if ( element ) {
+		if ( ! /^(?:a|select|input|button|textarea)$/i.test( element.tagName ) ) {
+			element.tabIndex = -1;
+		}
+		element.focus();
+	}
 }, false);


### PR DESCRIPTION
Fix whitespace, use single quotes, add `use strict`.