### PR TITLE
Explicitly remove .genesis-skip-link margin

### DIFF
--- a/css/genwpacc-skiplinks.css
+++ b/css/genwpacc-skiplinks.css
@@ -47,6 +47,10 @@
 
 /* Skip link
 --------------------------------------------- */
+.genesis-skip-link {
+	margin: 0;
+}
+
 .genesis-skip-link li {
 	height: 0;
 	width: 0;


### PR DESCRIPTION
Added CSS to explicitly remove the margin of .genesis-skip-link. Current child theme only uses Normalize as a baseline, meaning margin's on list elements are set to user agent default of 0.67em top and bottom. Activating Genesis Accessible in this case caused whitespace to appear around the collapsed .genesis-skip-link.