### PR TITLE
Fix error (version) message and typo

### DIFF
--- a/genesis-accessible.php
+++ b/genesis-accessible.php
@@ -84,7 +84,7 @@ function genwpacc_activation_check() {
 
 		deactivate_plugins( plugin_basename( __FILE__ ) );  // Deactivate ourself
 
-		wp_die( sprintf( __( 'Whoa.. the Genesis Accessible plugin only works, really, when you have installed the %1$sGenesis Framework%2$s', GENWPACC_DOMAIN ), '<a href="http://www.shareasale.com/r.cfm?b=346198&u=629895&m=28169&urllink=&afftrack=">Genesis Framework</a>', '</a>' ) );
+		wp_die( sprintf( __( 'Whoa.. the Genesis Accessible plugin only works, really, when you have installed the %1$s.', GENWPACC_DOMAIN ), '<a href="http://www.shareasale.com/r.cfm?b=346198&u=629895&m=28169&urllink=&afftrack=">Genesis Framework</a>' ) );
 
 	}
 
@@ -93,7 +93,7 @@ function genwpacc_activation_check() {
 
         deactivate_plugins( plugin_basename( __FILE__ ) );  // Deactivate ourself
 
-		wp_die( sprintf( __( 'Uhm, the thing of it is, you kinda need the %1$sGenesis Framework %2$s%3$s or greater for these plugin to make any sense.', GENWPACC_DOMAIN ), '<a href="http://www.shareasale.com/r.cfm?b=346198&u=629895&m=28169&urllink=&afftrack=">Genesis Framework</a>', $latest, '</a>' ) );
+		wp_die( sprintf( __( 'Uhm, the thing of it is, you kinda need the %1$s %2$s or greater for this plugin to make any sense.', GENWPACC_DOMAIN ), '<a href="http://www.shareasale.com/r.cfm?b=346198&u=629895&m=28169&urllink=&afftrack=">Genesis Framework</a>', $minimum_genesis_version ) );
 
 	}
 


### PR DESCRIPTION
In short, this fixes the error message in general, displays the minimum required Genesis framework version and renames "these" to "this".

It also adds a period (dot) at the end of the first sentence.

![snag_program-0016](https://cloud.githubusercontent.com/assets/1499293/7848529/d1db5a9a-04cc-11e5-87ee-721d230d404b.png)